### PR TITLE
remove weird zero from non-admins list-books page

### DIFF
--- a/src/components/pages/listBooksPage/ListBooks.tsx
+++ b/src/components/pages/listBooksPage/ListBooks.tsx
@@ -300,7 +300,8 @@ const ListBooks: FC = (): JSX.Element => {
                 >
                     <AccountBoxIcon />
                 </Fab>
-                {context?.user?.administrator && (
+                {
+                context?.user?.administrator ?
                     <Fab
                         aria-label="admin"
                         sx={addButton}
@@ -310,7 +311,8 @@ const ListBooks: FC = (): JSX.Element => {
                     >
                         <AdminPanelSettingsIcon />
                     </Fab>
-                )}
+                    : <></>
+                }
                 <Stack spacing={3} sx={{ margin: "auto", width: "60%" }}>
                     {books?.map((book) => renderBookData(book))}
                 </Stack>


### PR DESCRIPTION
Changed check for the admin button to not output a 0 on the list-books page when logged in as a normal user.