### PR TITLE
Fix eslint warning about missing dependency in useEffect

### DIFF
--- a/src/components/scanner/AddScanner.tsx
+++ b/src/components/scanner/AddScanner.tsx
@@ -20,7 +20,6 @@ const AddScanner: FC<IProps> = ({
   setConfirmation,
   callApi,
 }: IProps): JSX.Element => {
-
   const scanner = useCallback(() => {
     let html5QrcodeScanner = new Html5QrcodeScanner(
       qrcodeRegionId,
@@ -52,7 +51,7 @@ const AddScanner: FC<IProps> = ({
     const timeoutId = setTimeout(() => {
       scanner();
     }, 1);
-    
+
     return () => clearTimeout(timeoutId);
   }, [visible, scanner]);
 

--- a/src/components/scanner/AddScanner.tsx
+++ b/src/components/scanner/AddScanner.tsx
@@ -1,11 +1,8 @@
-import { useState, FC, useEffect } from "react";
-import { Modal, Box, Button } from "@mui/material";
-
-import Book from "../../interfaces/book.interface";
-import BookForm from "../pages/listBooksPage/BookForm";
+import { FC, useEffect, useCallback } from "react";
+import { Modal, Box } from "@mui/material";
 
 import { editBookBox } from "../../sxStyles";
-import { Html5QrcodeScanner, Html5Qrcode } from "html5-qrcode";
+import { Html5QrcodeScanner } from "html5-qrcode";
 const qrcodeRegionId = "html5qr-code-full-region";
 
 interface IProps {
@@ -23,24 +20,8 @@ const AddScanner: FC<IProps> = ({
   setConfirmation,
   callApi,
 }: IProps): JSX.Element => {
-  const [formVisible, setFormVisible] = useState(false);
-  const [popUpConfirmation, setPopUpConfirmationOpen] = useState({
-    ok: false,
-    message: "",
-  });
 
-  useEffect(() => {
-    if (!visible) {
-      return;
-    }
-
-    const timeoutId = setTimeout(() => {
-      scanner();
-    }, 1);
-    return () => clearTimeout(timeoutId);
-  }, [visible]);
-
-  const scanner = () => {
+  const scanner = useCallback(() => {
     let html5QrcodeScanner = new Html5QrcodeScanner(
       qrcodeRegionId,
       { fps: 10, qrbox: { width: 200, height: 200 } },
@@ -61,7 +42,19 @@ const AddScanner: FC<IProps> = ({
     }
 
     html5QrcodeScanner.render(onScanSuccess, onScanFailure);
-  };
+  }, [callApi, setConfirmation, setVisible]);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      scanner();
+    }, 1);
+    
+    return () => clearTimeout(timeoutId);
+  }, [visible, scanner]);
 
   return (
     <Modal open={visible} onClose={() => setVisible(false)}>


### PR DESCRIPTION
There was an eslint warning that would stop the app from building on the Node.js CI workflow, because it was treated as an error.
It was added with the scanner and I just noticed at some point that the app wasn't building (screenshot below).
I added the dependency, wrapped the function in a callback and removed some unnecessary imports.

![image](https://user-images.githubusercontent.com/52527410/235117105-22cd6064-f001-42e2-9f43-6db95380b6d2.png)