### PR TITLE
Handling for when the cover image is not found

### DIFF
--- a/src/components/pages/listBooksPage/BookForm.tsx
+++ b/src/components/pages/listBooksPage/BookForm.tsx
@@ -98,7 +98,7 @@ const EditBook: FC<IProps> = ({
             ...book,
             isbn: isbn,
             author: bookData.volumeInfo.authors[0],
-            image: "https://images.isbndb.com/covers/91/26/9789513119126.jpg",
+            image: null,
             title: bookData.volumeInfo.title,
             year: date[0] + date[1] + date[2] + date[3],
           });

--- a/src/components/pages/listBooksPage/ListBooks.tsx
+++ b/src/components/pages/listBooksPage/ListBooks.tsx
@@ -208,7 +208,6 @@ const ListBooks: FC = (): JSX.Element => {
 
   const handleChangePage = (event: unknown, newPage: number) => {
     setPage(newPage);
-    console.log(books);
   };
 
   const handleChangeRowsPerPage = (
@@ -330,7 +329,23 @@ const ListBooks: FC = (): JSX.Element => {
             }}
           >
             <Stack>
-              <img alt="Book cover" width={120} height={160} src={book.image} />
+              {book.image ? (
+                <img
+                  alt="Book cover"
+                  width={120}
+                  height={160}
+                  src={book.image}
+                />
+              ) : (
+                <img
+                  alt="Book cover not available"
+                  width={120}
+                  height={160}
+                  src={
+                    "https://images.isbndb.com/covers/91/26/9789513119126.jpg"
+                  }
+                />
+              )}
             </Stack>
 
             <Stack>


### PR DESCRIPTION
How it was done before is that if the book image is not found in the api, an image link would be still saved to db, it would just be a placeholder image.
Now if the api doesn't provide an image, it's saved as null to save space in the db. When listing the book, if the image is null, it's going to display the placeholder image.